### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/templates/callminer.json
+++ b/templates/callminer.json
@@ -260,7 +260,7 @@
                     "S3Bucket": "aws-quickstart",
                     "S3Key": "connect-integration-callminer/functions/packages/integration/lambda.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "30"
             }
         },


### PR DESCRIPTION
CloudFormation templates in connect-integration-callminer have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.